### PR TITLE
Renamed eval.py to evaluate.py to not conflict with built in function

### DIFF
--- a/DJSW/evaluate.py
+++ b/DJSW/evaluate.py
@@ -110,7 +110,3 @@ def evaluate_model(args):
     print(f"MAE: {mae:.4f}")
     print(f"R²: {r2:.4f}")
     print(f"Balanced Accuracy: {bacc:.4f}")
-
-
-def eval_model(args):
-    evaluate_model(args)

--- a/DJSW/main.py
+++ b/DJSW/main.py
@@ -12,7 +12,7 @@ import configargparse
 import torch
 import numpy as np
 import random
-from eval import eval_model
+from evaluate import evaluate_model
 from train import train_model
 # -----------------------------------------------------
 #Functions
@@ -57,7 +57,7 @@ def main(args):
     else:
         if args.load_checkpoint is None:
             raise ValueError("For evaluation, a model checkpoint must be provided using --load_checkpoint.")
-        eval_model(args)
+        evaluate_model(args)
 # -----------------------------------------------------
 if __name__ == '__main__':
     args = getArguments()

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Efficient Lumi-friendly ML Pipeline
     │
     ├── train.py                <- Code to train models
     │
-    ├── eval.py                 <- Code to evaluate trained models
+    ├── evaluate.py                 <- Code to evaluate trained models
     │
     └── main.py                 <- Main entrance script
 ```


### PR DESCRIPTION
Removed possible "duplicate" of eval_model, which only called evaluate_model.