### PR TITLE
Added GitHub Actions workflow for building and deploying documentation

### DIFF
--- a/.github/workflows/sphinx-builder.yml
+++ b/.github/workflows/sphinx-builder.yml
@@ -1,0 +1,45 @@
+name: Build documentation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up micromamba
+      uses: mamba-org/setup-micromamba@v1 #uses https://github.com/mamba-org/setup-micromamba
+      with:
+        micromamba-version: 'latest' # any version from https://github.com/mamba-org/micromamba-releases
+        environment-file: ''
+        auto-activate-base: true 
+        python-version: '3.12'
+        generate-run-shell: false
+
+    - name: Install dependencies
+      run: |
+        pip install -r docs/requirements-docs.txt
+          
+    - name: Sphinx build
+      run: |
+        sphinx-build docs docs/_build
+      shell: bash -el {0}
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v4
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      with:
+        publish_branch: gh-pages
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/_build/
+        force_orphan: true


### PR DESCRIPTION
Should be reviewed and added after #10. This has been tested on my own fork:   https://github.com/JohannesMorkrid/DJSW_collabrative_coding
Resulting in the following documentation (accepted #10 into main in fork):
https://johannesmorkrid.github.io/DJSW_collabrative_coding/