### PR TITLE
Github action warning patch

### DIFF
--- a/.github/workflows/sphinx-builder.yml
+++ b/.github/workflows/sphinx-builder.yml
@@ -23,7 +23,7 @@ jobs:
         create-args: >-
           python=3.12
           pip
-        environment-name: build-env
+        environment-name: docs-env
         micromamba-version: 'latest'
         generate-run-shell: false
 


### PR DESCRIPTION
Addresses: `Warning: Unexpected input(s) 'auto-activate-base', 'python-version'` in the jobs logs